### PR TITLE
Refactor: split ui into widget modules, replace git CLI with git2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -233,6 +235,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +272,12 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fax"
@@ -318,6 +337,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +353,33 @@ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
  "windows-link",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -362,10 +417,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "image"
@@ -429,10 +586,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.18.3+1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -451,6 +658,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -631,6 +844,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +929,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +993,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "ratatui"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,9 +1041,11 @@ dependencies = [
  "anyhow",
  "arboard",
  "crossterm",
+ "git2",
  "pretty_assertions",
  "ratatui",
  "syntect",
+ "tempfile",
  "tui-textarea",
 ]
 
@@ -946,6 +1194,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,6 +1245,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syntect"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,6 +1274,19 @@ dependencies = [
  "thiserror",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1077,6 +1355,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tui-textarea"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,6 +1411,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,6 +1449,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "weezl"
@@ -1338,6 +1659,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
 name = "x11rb"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1703,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,6 +1739,60 @@ name = "zerocopy-derive"
 version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ crossterm = "0.28"
 arboard = "3"
 syntect = "5"
 anyhow = "1"
+git2 = "0.20"
 tui-textarea = { version = "0.7", features = ["crossterm"] }
 
 [lints.rust]
@@ -18,3 +19,4 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
 
 [dev-dependencies]
 pretty_assertions = "1"
+tempfile = "3"

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use std::process::Command;
+use git2::{Delta, Diff, DiffOptions, Patch, Repository};
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -18,20 +18,62 @@ pub enum ChangeType {
     Renamed,
 }
 
-pub(crate) fn parse_numstat(output: &str) -> Vec<ChangedFile> {
+fn open_repo() -> Result<Repository> {
+    Repository::discover(".").context("Not a git repository")
+}
+
+fn main_tree(repo: &Repository) -> Result<git2::Tree<'_>> {
+    let branch = repo
+        .find_branch("main", git2::BranchType::Local)
+        .context("Could not find 'main' branch")?;
+    let commit = branch.get().peel_to_commit()?;
+    Ok(commit.tree()?)
+}
+
+fn diff_against_main(repo: &Repository, context_lines: u32) -> Result<Diff<'_>> {
+    let tree = main_tree(repo)?;
+    let mut opts = DiffOptions::new();
+    opts.include_untracked(true);
+    opts.show_untracked_content(true);
+    opts.recurse_untracked_dirs(true);
+    opts.context_lines(context_lines);
+    repo.diff_tree_to_workdir_with_index(Some(&tree), Some(&mut opts))
+        .context("Failed to compute diff against main")
+}
+
+pub(crate) fn delta_to_change_type(delta: Delta) -> Option<ChangeType> {
+    match delta {
+        Delta::Added | Delta::Untracked => Some(ChangeType::Added),
+        Delta::Deleted => Some(ChangeType::Deleted),
+        Delta::Modified => Some(ChangeType::Modified),
+        Delta::Renamed => Some(ChangeType::Renamed),
+        _ => None,
+    }
+}
+
+pub(crate) fn changed_files_from_diff(diff: &Diff<'_>) -> Vec<ChangedFile> {
     let mut files = Vec::new();
-    for line in output.lines() {
-        let parts: Vec<&str> = line.split('\t').collect();
-        if parts.len() < 3 {
+    for (i, delta) in diff.deltas().enumerate() {
+        let Some(change_type) = delta_to_change_type(delta.status()) else {
             continue;
-        }
-        let additions = parts[0].parse().unwrap_or(0);
-        let deletions = parts[1].parse().unwrap_or(0);
-        let path = parts[2].to_string();
+        };
+        let path = delta
+            .new_file()
+            .path()
+            .or_else(|| delta.old_file().path())
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
+
+        let (additions, deletions) = Patch::from_diff(diff, i)
+            .ok()
+            .flatten()
+            .and_then(|p| p.line_stats().ok())
+            .map(|(_ctx, add, del)| (add, del))
+            .unwrap_or((0, 0));
 
         files.push(ChangedFile {
             path,
-            change_type: ChangeType::Modified, // refined by parse_name_status
+            change_type,
             additions,
             deletions,
         });
@@ -39,212 +81,300 @@ pub(crate) fn parse_numstat(output: &str) -> Vec<ChangedFile> {
     files
 }
 
-pub(crate) fn parse_name_status(output: &str, files: &mut [ChangedFile]) {
-    for line in output.lines() {
-        let parts: Vec<&str> = line.split('\t').collect();
-        if parts.len() < 2 {
-            continue;
+pub(crate) fn format_diff_patch(diff: &Diff<'_>) -> Result<String> {
+    let mut output = String::new();
+    diff.print(git2::DiffFormat::Patch, |_delta, _hunk, line| {
+        let origin = line.origin();
+        // Only prepend origin for actual diff lines (+, -, space)
+        // File headers (F/>) and hunk headers (H) are emitted as-is
+        match origin {
+            '+' | '-' | ' ' => output.push(origin),
+            _ => {}
         }
-        let change_type = match parts[0].chars().next() {
-            Some('A') => ChangeType::Added,
-            Some('D') => ChangeType::Deleted,
-            Some('R') => ChangeType::Renamed,
-            _ => ChangeType::Modified,
-        };
-        let path = parts.last().unwrap().to_string();
-        if let Some(f) = files.iter_mut().find(|f| f.path == path) {
-            f.change_type = change_type;
+        if let Ok(content) = std::str::from_utf8(line.content()) {
+            output.push_str(content);
         }
-    }
+        true
+    })?;
+    Ok(output)
 }
 
 #[cfg(not(tarpaulin_include))]
 pub fn get_changed_files() -> Result<Vec<ChangedFile>> {
-    let output = Command::new("git")
-        .args(["diff", "--numstat", "--diff-filter=ADMR", "main"])
-        .output()
-        .context("Failed to run git diff")?;
-
-    if !output.status.success() {
-        let err = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git diff failed: {}", err);
-    }
-
-    let stdout = String::from_utf8(output.stdout)?;
-    let mut files = parse_numstat(&stdout);
-
-    // Get change types
-    let type_output = Command::new("git")
-        .args(["diff", "--name-status", "--diff-filter=ADMR", "main"])
-        .output()
-        .context("Failed to run git diff --name-status")?;
-
-    let type_stdout = String::from_utf8(type_output.stdout)?;
-    parse_name_status(&type_stdout, &mut files);
-
-    Ok(files)
+    let repo = open_repo()?;
+    let diff = diff_against_main(&repo, 3)?;
+    Ok(changed_files_from_diff(&diff))
 }
 
 #[cfg(not(tarpaulin_include))]
 pub fn get_file_diff(path: &str) -> Result<String> {
-    // Count lines in the working-tree copy so we can request full-file context.
-    // git diff has no "unlimited context" flag, so we pass the file's line count.
+    let repo = open_repo()?;
+    let tree = main_tree(&repo)?;
+
+    // Use full-file context: read line count from working copy
     let line_count = std::fs::read_to_string(path)
         .map(|s| s.lines().count())
-        .unwrap_or(0);
-    let context_flag = format!("-U{}", line_count);
+        .unwrap_or(0) as u32;
 
-    let output = Command::new("git")
-        .args(["diff", &context_flag, "main", "--", path])
-        .output()
-        .context("Failed to run git diff for file")?;
+    let mut opts = DiffOptions::new();
+    opts.pathspec(path);
+    opts.include_untracked(true);
+    opts.show_untracked_content(true);
+    opts.recurse_untracked_dirs(true);
+    opts.context_lines(line_count);
 
-    Ok(String::from_utf8(output.stdout)?)
+    let diff = repo
+        .diff_tree_to_workdir_with_index(Some(&tree), Some(&mut opts))
+        .context("Failed to compute file diff")?;
+
+    format_diff_patch(&diff)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::path::Path;
 
-    // ── parse_numstat tests ──────────────────────────────────────────
+    /// Create a temp repo with an initial commit on "main" branch.
+    fn setup_repo() -> (tempfile::TempDir, Repository) {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+
+        // Configure a dummy author for commits
+        let mut config = repo.config().unwrap();
+        config.set_str("user.name", "Test").unwrap();
+        config.set_str("user.email", "test@test.com").unwrap();
+
+        // Create initial commit on main
+        let file_path = dir.path().join("initial.txt");
+        fs::write(&file_path, "hello\n").unwrap();
+
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new("initial.txt")).unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let sig = repo.signature().unwrap();
+        let commit_oid = {
+            let tree = repo.find_tree(tree_oid).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "initial commit", &tree, &[])
+                .unwrap()
+        };
+
+        // Create "main" branch pointing to this commit
+        {
+            let commit = repo.find_commit(commit_oid).unwrap();
+            repo.branch("main", &commit, false).unwrap();
+        }
+
+        (dir, repo)
+    }
+
+    // ── delta_to_change_type ─────────────────────────────────────────
 
     #[test]
-    fn parse_numstat_empty_input() {
-        let files = parse_numstat("");
+    fn delta_to_change_type_added() {
+        assert_eq!(delta_to_change_type(Delta::Added), Some(ChangeType::Added));
+    }
+
+    #[test]
+    fn delta_to_change_type_untracked() {
+        assert_eq!(
+            delta_to_change_type(Delta::Untracked),
+            Some(ChangeType::Added)
+        );
+    }
+
+    #[test]
+    fn delta_to_change_type_deleted() {
+        assert_eq!(
+            delta_to_change_type(Delta::Deleted),
+            Some(ChangeType::Deleted)
+        );
+    }
+
+    #[test]
+    fn delta_to_change_type_modified() {
+        assert_eq!(
+            delta_to_change_type(Delta::Modified),
+            Some(ChangeType::Modified)
+        );
+    }
+
+    #[test]
+    fn delta_to_change_type_renamed() {
+        assert_eq!(
+            delta_to_change_type(Delta::Renamed),
+            Some(ChangeType::Renamed)
+        );
+    }
+
+    #[test]
+    fn delta_to_change_type_ignored_returns_none() {
+        assert_eq!(delta_to_change_type(Delta::Ignored), None);
+    }
+
+    #[test]
+    fn delta_to_change_type_unmodified_returns_none() {
+        assert_eq!(delta_to_change_type(Delta::Unmodified), None);
+    }
+
+    // ── changed_files_from_diff ──────────────────────────────────────
+
+    #[test]
+    fn changed_files_detects_modified_file() {
+        let (dir, repo) = setup_repo();
+        fs::write(dir.path().join("initial.txt"), "hello\nworld\n").unwrap();
+
+        let diff = diff_against_main(&repo, 3).unwrap();
+        let files = changed_files_from_diff(&diff);
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "initial.txt");
+        assert_eq!(files[0].change_type, ChangeType::Modified);
+        assert_eq!(files[0].additions, 1); // added "world"
+    }
+
+    #[test]
+    fn changed_files_detects_untracked_file() {
+        let (dir, repo) = setup_repo();
+        fs::write(dir.path().join("new_file.txt"), "brand new\n").unwrap();
+
+        let diff = diff_against_main(&repo, 3).unwrap();
+        let files = changed_files_from_diff(&diff);
+
+        let new = files.iter().find(|f| f.path == "new_file.txt").unwrap();
+        assert_eq!(new.change_type, ChangeType::Added);
+        assert_eq!(new.additions, 1);
+    }
+
+    #[test]
+    fn changed_files_detects_deleted_file() {
+        let (dir, repo) = setup_repo();
+        fs::remove_file(dir.path().join("initial.txt")).unwrap();
+
+        let diff = diff_against_main(&repo, 3).unwrap();
+        let files = changed_files_from_diff(&diff);
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "initial.txt");
+        assert_eq!(files[0].change_type, ChangeType::Deleted);
+        assert_eq!(files[0].deletions, 1);
+    }
+
+    #[test]
+    fn changed_files_no_changes_returns_empty() {
+        let (_dir, repo) = setup_repo();
+
+        let diff = diff_against_main(&repo, 3).unwrap();
+        let files = changed_files_from_diff(&diff);
+
         assert!(files.is_empty());
     }
 
     #[test]
-    fn parse_numstat_single_file() {
-        let input = "10\t5\tpath/to/file.rs";
-        let files = parse_numstat(input);
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].path, "path/to/file.rs");
-        assert_eq!(files[0].additions, 10);
-        assert_eq!(files[0].deletions, 5);
-    }
+    fn changed_files_multiple_changes() {
+        let (dir, repo) = setup_repo();
+        fs::write(dir.path().join("initial.txt"), "changed\n").unwrap();
+        fs::write(dir.path().join("added.txt"), "new content\n").unwrap();
 
-    #[test]
-    fn parse_numstat_multiple_files() {
-        let input = "10\t5\tsrc/main.rs\n3\t1\tsrc/lib.rs\n20\t0\tREADME.md";
-        let files = parse_numstat(input);
-        assert_eq!(files.len(), 3);
-        assert_eq!(files[0].path, "src/main.rs");
-        assert_eq!(files[1].path, "src/lib.rs");
-        assert_eq!(files[1].additions, 3);
-        assert_eq!(files[1].deletions, 1);
-        assert_eq!(files[2].path, "README.md");
-        assert_eq!(files[2].additions, 20);
-        assert_eq!(files[2].deletions, 0);
-    }
+        let diff = diff_against_main(&repo, 3).unwrap();
+        let files = changed_files_from_diff(&diff);
 
-    #[test]
-    fn parse_numstat_binary_file() {
-        let input = "-\t-\timage.png";
-        let files = parse_numstat(input);
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].path, "image.png");
-        assert_eq!(files[0].additions, 0);
-        assert_eq!(files[0].deletions, 0);
-    }
-
-    #[test]
-    fn parse_numstat_malformed_line_skipped() {
-        let input = "10\t5\tgood.rs\nmalformed_line\n8\t2\talso_good.rs";
-        let files = parse_numstat(input);
         assert_eq!(files.len(), 2);
-        assert_eq!(files[0].path, "good.rs");
-        assert_eq!(files[1].path, "also_good.rs");
-    }
-
-    // ── parse_name_status tests ──────────────────────────────────────
-
-    #[test]
-    fn parse_name_status_added_file() {
-        let mut files = vec![ChangedFile {
-            path: "new_file.rs".to_string(),
-            change_type: ChangeType::Modified,
-            additions: 10,
-            deletions: 0,
-        }];
-        parse_name_status("A\tnew_file.rs", &mut files);
-        assert_eq!(files[0].change_type, ChangeType::Added);
+        let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+        assert!(paths.contains(&"initial.txt"));
+        assert!(paths.contains(&"added.txt"));
     }
 
     #[test]
-    fn parse_name_status_modified_file() {
-        let mut files = vec![ChangedFile {
-            path: "existing.rs".to_string(),
-            change_type: ChangeType::Modified,
-            additions: 5,
-            deletions: 3,
-        }];
-        parse_name_status("M\texisting.rs", &mut files);
-        assert_eq!(files[0].change_type, ChangeType::Modified);
+    fn changed_files_untracked_in_subdirectory() {
+        let (dir, repo) = setup_repo();
+        let subdir = dir.path().join("src");
+        fs::create_dir_all(&subdir).unwrap();
+        fs::write(subdir.join("lib.rs"), "fn main() {}\n").unwrap();
+
+        let diff = diff_against_main(&repo, 3).unwrap();
+        let files = changed_files_from_diff(&diff);
+
+        let new = files.iter().find(|f| f.path == "src/lib.rs").unwrap();
+        assert_eq!(new.change_type, ChangeType::Added);
+    }
+
+    // ── format_diff_patch ────────────────────────────────────────────
+
+    #[test]
+    fn format_diff_patch_modified_file() {
+        let (dir, repo) = setup_repo();
+        fs::write(dir.path().join("initial.txt"), "hello\nworld\n").unwrap();
+
+        let diff = diff_against_main(&repo, 3).unwrap();
+        let patch = format_diff_patch(&diff).unwrap();
+
+        assert!(patch.contains("+world"));
+        assert!(patch.contains("@@ "));
     }
 
     #[test]
-    fn parse_name_status_deleted_file() {
-        let mut files = vec![ChangedFile {
-            path: "old.rs".to_string(),
-            change_type: ChangeType::Modified,
-            additions: 0,
-            deletions: 50,
-        }];
-        parse_name_status("D\told.rs", &mut files);
-        assert_eq!(files[0].change_type, ChangeType::Deleted);
+    fn format_diff_patch_untracked_file() {
+        let (dir, repo) = setup_repo();
+        fs::write(dir.path().join("brand_new.txt"), "line1\nline2\n").unwrap();
+
+        let mut opts = DiffOptions::new();
+        opts.pathspec("brand_new.txt");
+        opts.include_untracked(true);
+        opts.show_untracked_content(true);
+
+        let tree = main_tree(&repo).unwrap();
+        let diff = repo
+            .diff_tree_to_workdir_with_index(Some(&tree), Some(&mut opts))
+            .unwrap();
+        let patch = format_diff_patch(&diff).unwrap();
+
+        assert!(patch.contains("+line1"));
+        assert!(patch.contains("+line2"));
     }
 
     #[test]
-    fn parse_name_status_renamed_file() {
-        let mut files = vec![ChangedFile {
-            path: "new_name.rs".to_string(),
-            change_type: ChangeType::Modified,
-            additions: 2,
-            deletions: 1,
-        }];
-        parse_name_status("R100\told_name.rs\tnew_name.rs", &mut files);
-        assert_eq!(files[0].change_type, ChangeType::Renamed);
+    fn format_diff_patch_deleted_file() {
+        let (dir, repo) = setup_repo();
+        fs::remove_file(dir.path().join("initial.txt")).unwrap();
+
+        let diff = diff_against_main(&repo, 3).unwrap();
+        let patch = format_diff_patch(&diff).unwrap();
+
+        assert!(patch.contains("-hello"));
     }
 
     #[test]
-    fn parse_name_status_missing_file_ignored() {
-        let mut files = vec![ChangedFile {
-            path: "exists.rs".to_string(),
-            change_type: ChangeType::Modified,
-            additions: 1,
-            deletions: 1,
-        }];
-        parse_name_status("A\tnot_in_vec.rs", &mut files);
-        // The existing file should remain unchanged
-        assert_eq!(files[0].change_type, ChangeType::Modified);
-        assert_eq!(files.len(), 1);
+    fn format_diff_patch_empty_diff() {
+        let (_dir, repo) = setup_repo();
+
+        let diff = diff_against_main(&repo, 3).unwrap();
+        let patch = format_diff_patch(&diff).unwrap();
+
+        assert!(patch.is_empty());
     }
 
     #[test]
-    fn parse_name_status_malformed_line_skipped() {
-        let mut files = vec![ChangedFile {
-            path: "file.rs".to_string(),
-            change_type: ChangeType::Modified,
-            additions: 1,
-            deletions: 0,
-        }];
-        // Line with no tab separator should be skipped (hits the continue on line 45)
-        parse_name_status("A\tfile.rs\nmalformed_no_tab\nD\tfile.rs", &mut files);
-        // The last status wins: Deleted
-        assert_eq!(files[0].change_type, ChangeType::Deleted);
-    }
+    fn format_diff_patch_context_lines() {
+        let (dir, repo) = setup_repo();
+        fs::write(dir.path().join("initial.txt"), "hello\nnew line\n").unwrap();
 
-    #[test]
-    fn parse_name_status_empty_input() {
-        let mut files = vec![ChangedFile {
-            path: "file.rs".to_string(),
-            change_type: ChangeType::Modified,
-            additions: 1,
-            deletions: 0,
-        }];
-        parse_name_status("", &mut files);
-        // No changes should have been made
-        assert_eq!(files[0].change_type, ChangeType::Modified);
+        // Request full context
+        let tree = main_tree(&repo).unwrap();
+        let mut opts = DiffOptions::new();
+        opts.pathspec("initial.txt");
+        opts.include_untracked(true);
+        opts.context_lines(100);
+
+        let diff = repo
+            .diff_tree_to_workdir_with_index(Some(&tree), Some(&mut opts))
+            .unwrap();
+        let patch = format_diff_patch(&diff).unwrap();
+
+        // Context line for unchanged "hello" and addition of "new line"
+        assert!(patch.contains(" hello"));
+        assert!(patch.contains("+new line"));
     }
 }

--- a/src/ui/diff.rs
+++ b/src/ui/diff.rs
@@ -1,0 +1,199 @@
+use crate::app::{App, Mode};
+use crate::diff::DiffLine;
+use crate::diff::LineType;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, StatefulWidget, Widget};
+
+pub struct DiffWidget;
+
+impl StatefulWidget for DiffWidget {
+    type State = App;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut App) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(format!(
+                " {} ",
+                state.current_file.as_deref().unwrap_or("No file selected")
+            ))
+            .border_style(Style::default().fg(Color::DarkGray));
+
+        let inner = block.inner(area);
+        block.render(area, buf);
+
+        let Some(diff) = &state.current_diff else {
+            Paragraph::new("Click a file to view its diff").render(inner, buf);
+            return;
+        };
+
+        let mut lines: Vec<Line> = Vec::new();
+        let file_comments = state
+            .current_file
+            .as_ref()
+            .and_then(|f| state.comments.get(f));
+
+        let all_diff_lines: Vec<_> = diff.hunks.iter().flat_map(|h| h.lines.iter()).collect();
+
+        for (idx, diff_line) in all_diff_lines.iter().enumerate() {
+            let (style, prefix) = match diff_line.line_type {
+                LineType::Addition => (Style::default().fg(Color::Green), "+"),
+                LineType::Deletion => (Style::default().fg(Color::Red), "-"),
+                LineType::Context => (Style::default().fg(Color::White), " "),
+                LineType::HunkHeader => (
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                    "",
+                ),
+            };
+
+            let line_no = match diff_line.line_type {
+                LineType::HunkHeader => "   ".to_string(),
+                _ => {
+                    let n = diff_line.new_line_no.or(diff_line.old_line_no);
+                    n.map_or("   ".to_string(), |n| format!("{:>3}", n))
+                }
+            };
+
+            // Replace tabs with spaces and apply horizontal scroll
+            let content = diff_line.content.replace('\t', "    ");
+            let visible_content: String = content.chars().skip(state.diff_hscroll).collect();
+
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("{} ", line_no),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(format!("{}{}", prefix, visible_content), style),
+            ]));
+
+            // Render inline comments for this line
+            if let Some(comments) = file_comments {
+                for comment in comments.iter().filter(|c| c.line_index == idx) {
+                    lines.push(Line::from(vec![
+                        Span::styled("       > ", Style::default().fg(Color::Magenta)),
+                        Span::styled(
+                            comment.text.clone(),
+                            Style::default()
+                                .fg(Color::Magenta)
+                                .add_modifier(Modifier::ITALIC),
+                        ),
+                    ]));
+                }
+            }
+
+            // Show input line if commenting on this line
+            if state.mode == Mode::Commenting && state.commenting_line == Some(idx) {
+                let text = state.input_text();
+                lines.push(Line::from(vec![
+                    Span::styled("       > ", Style::default().fg(Color::Yellow)),
+                    Span::styled(text, Style::default().fg(Color::Yellow)),
+                    Span::styled("_", Style::default().fg(Color::Yellow)),
+                ]));
+            }
+        }
+
+        // Apply scroll (clamp and write back so future scroll-up works immediately)
+        let total_lines = lines.len();
+        let visible_height = inner.height as usize;
+        let max_scroll = total_lines.saturating_sub(visible_height);
+        state.diff_scroll = state.diff_scroll.min(max_scroll);
+        let visible_lines: Vec<Line> = lines
+            .into_iter()
+            .skip(state.diff_scroll)
+            .take(visible_height)
+            .collect();
+
+        Paragraph::new(visible_lines).render(inner, buf);
+
+        // Render change map (scrollbar with colored change indicators)
+        if total_lines > 0 {
+            render_change_map(
+                buf,
+                &all_diff_lines,
+                total_lines,
+                visible_height,
+                state.diff_scroll,
+                inner,
+            );
+        }
+    }
+}
+
+/// Renders a 1-column change map on the right edge of the diff area.
+/// Each row maps proportionally to the full file; additions are green,
+/// deletions are red, and the current viewport is shown as a bright thumb.
+fn render_change_map(
+    buf: &mut Buffer,
+    diff_lines: &[&DiffLine],
+    total_rendered: usize,
+    visible_height: usize,
+    scroll: usize,
+    inner: Rect,
+) {
+    let height = inner.height as usize;
+    if height == 0 || diff_lines.is_empty() {
+        return;
+    }
+
+    let col = inner.x + inner.width.saturating_sub(1);
+
+    // Thumb range (viewport indicator)
+    let thumb_start = if total_rendered <= visible_height {
+        0
+    } else {
+        scroll * height / total_rendered
+    };
+    let thumb_len = if total_rendered <= visible_height {
+        height
+    } else {
+        (visible_height * height / total_rendered).max(1)
+    };
+    let thumb_end = (thumb_start + thumb_len).min(height);
+
+    for row in 0..height {
+        // Map this gutter row to a range of diff lines and find the most
+        // significant change type (Addition > Deletion > Context).
+        let range_start = row * diff_lines.len() / height;
+        let range_end = ((row + 1) * diff_lines.len() / height).min(diff_lines.len());
+        let mut has_addition = false;
+        let mut has_deletion = false;
+        for i in range_start..range_end.max(range_start + 1) {
+            match diff_lines[i.min(diff_lines.len() - 1)].line_type {
+                LineType::Addition => has_addition = true,
+                LineType::Deletion => has_deletion = true,
+                _ => {}
+            }
+        }
+
+        let is_thumb = row >= thumb_start && row < thumb_end;
+
+        let (ch, fg, bg) = if has_addition {
+            if is_thumb {
+                ("▐", Color::Green, Color::DarkGray)
+            } else {
+                ("▐", Color::Green, Color::Reset)
+            }
+        } else if has_deletion {
+            if is_thumb {
+                ("▐", Color::Red, Color::DarkGray)
+            } else {
+                ("▐", Color::Red, Color::Reset)
+            }
+        } else if is_thumb {
+            ("█", Color::DarkGray, Color::Reset)
+        } else {
+            ("│", Color::Rgb(40, 40, 40), Color::Reset)
+        };
+
+        let y = inner.y + row as u16;
+        if y < inner.y + inner.height {
+            let cell = &mut buf[(col, y)];
+            cell.set_symbol(ch);
+            cell.set_style(Style::default().fg(fg).bg(bg));
+        }
+    }
+}

--- a/src/ui/file_list.rs
+++ b/src/ui/file_list.rs
@@ -1,0 +1,65 @@
+use crate::app::App;
+use crate::git::ChangeType;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, StatefulWidget};
+
+use super::short_path;
+
+pub struct FileListWidget;
+
+impl StatefulWidget for FileListWidget {
+    type State = App;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut App) {
+        let items: Vec<ListItem> = state
+            .files
+            .iter()
+            .map(|f| {
+                let indicator = match f.change_type {
+                    ChangeType::Added => ("A", Color::Green),
+                    ChangeType::Modified => ("M", Color::Yellow),
+                    ChangeType::Deleted => ("D", Color::Red),
+                    ChangeType::Renamed => ("R", Color::Cyan),
+                };
+
+                let comment_count = state.file_comment_count(&f.path);
+                let comment_badge = if comment_count > 0 {
+                    format!(" [{}]", comment_count)
+                } else {
+                    String::new()
+                };
+
+                let line = Line::from(vec![
+                    Span::styled(
+                        format!("{} ", indicator.0),
+                        Style::default()
+                            .fg(indicator.1)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::raw(short_path(&f.path)),
+                    Span::styled(comment_badge, Style::default().fg(Color::Magenta)),
+                ]);
+
+                ListItem::new(line)
+            })
+            .collect();
+
+        let list = List::new(items)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Files ")
+                    .border_style(Style::default().fg(Color::DarkGray)),
+            )
+            .highlight_style(
+                Style::default()
+                    .bg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD),
+            );
+
+        StatefulWidget::render(list, area, buf, &mut state.file_list_state);
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,12 +1,13 @@
-use crate::app::{App, Mode};
-use crate::diff::DiffLine;
-use crate::diff::LineType;
-use crate::git::ChangeType;
+mod diff;
+mod file_list;
+mod status_bar;
+
+use crate::app::App;
+use diff::DiffWidget;
+use file_list::FileListWidget;
 use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
 use ratatui::Frame;
+use status_bar::StatusBarWidget;
 
 /// Width of the file list sidebar
 const FILE_LIST_WIDTH: u16 = 22;
@@ -19,286 +20,9 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         Layout::horizontal([Constraint::Fill(1), Constraint::Length(FILE_LIST_WIDTH)])
             .areas(main_area);
 
-    render_file_list(frame, app, file_list_area);
-    render_diff(frame, app, diff_area);
-    render_status_bar(frame, app, status_area);
-}
-
-fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
-    let items: Vec<ListItem> = app
-        .files
-        .iter()
-        .map(|f| {
-            let indicator = match f.change_type {
-                ChangeType::Added => ("A", Color::Green),
-                ChangeType::Modified => ("M", Color::Yellow),
-                ChangeType::Deleted => ("D", Color::Red),
-                ChangeType::Renamed => ("R", Color::Cyan),
-            };
-
-            let comment_count = app.file_comment_count(&f.path);
-            let comment_badge = if comment_count > 0 {
-                format!(" [{}]", comment_count)
-            } else {
-                String::new()
-            };
-
-            let line = Line::from(vec![
-                Span::styled(
-                    format!("{} ", indicator.0),
-                    Style::default()
-                        .fg(indicator.1)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::raw(short_path(&f.path)),
-                Span::styled(comment_badge, Style::default().fg(Color::Magenta)),
-            ]);
-
-            ListItem::new(line)
-        })
-        .collect();
-
-    let list = List::new(items)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" Files ")
-                .border_style(Style::default().fg(Color::DarkGray)),
-        )
-        .highlight_style(
-            Style::default()
-                .bg(Color::DarkGray)
-                .add_modifier(Modifier::BOLD),
-        );
-
-    frame.render_stateful_widget(list, area, &mut app.file_list_state);
-}
-
-fn render_diff(frame: &mut Frame, app: &mut App, area: Rect) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .title(format!(
-            " {} ",
-            app.current_file.as_deref().unwrap_or("No file selected")
-        ))
-        .border_style(Style::default().fg(Color::DarkGray));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
-
-    let Some(diff) = &app.current_diff else {
-        let hint = Paragraph::new("Click a file to view its diff");
-        frame.render_widget(hint, inner);
-        return;
-    };
-
-    let mut lines: Vec<Line> = Vec::new();
-    let file_comments = app.current_file.as_ref().and_then(|f| app.comments.get(f));
-
-    let all_diff_lines: Vec<_> = diff.hunks.iter().flat_map(|h| h.lines.iter()).collect();
-
-    for (idx, diff_line) in all_diff_lines.iter().enumerate() {
-        let (style, prefix) = match diff_line.line_type {
-            LineType::Addition => (Style::default().fg(Color::Green), "+"),
-            LineType::Deletion => (Style::default().fg(Color::Red), "-"),
-            LineType::Context => (Style::default().fg(Color::White), " "),
-            LineType::HunkHeader => (
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-                "",
-            ),
-        };
-
-        let line_no = match diff_line.line_type {
-            LineType::HunkHeader => "   ".to_string(),
-            _ => {
-                let n = diff_line.new_line_no.or(diff_line.old_line_no);
-                n.map_or("   ".to_string(), |n| format!("{:>3}", n))
-            }
-        };
-
-        // Replace tabs with spaces and apply horizontal scroll
-        let content = diff_line.content.replace('\t', "    ");
-        let visible_content: String = content.chars().skip(app.diff_hscroll).collect();
-
-        lines.push(Line::from(vec![
-            Span::styled(
-                format!("{} ", line_no),
-                Style::default().fg(Color::DarkGray),
-            ),
-            Span::styled(format!("{}{}", prefix, visible_content), style),
-        ]));
-
-        // Render inline comments for this line
-        if let Some(comments) = file_comments {
-            for comment in comments.iter().filter(|c| c.line_index == idx) {
-                lines.push(Line::from(vec![
-                    Span::styled("       > ", Style::default().fg(Color::Magenta)),
-                    Span::styled(
-                        comment.text.clone(),
-                        Style::default()
-                            .fg(Color::Magenta)
-                            .add_modifier(Modifier::ITALIC),
-                    ),
-                ]));
-            }
-        }
-
-        // Show input line if commenting on this line
-        if app.mode == Mode::Commenting && app.commenting_line == Some(idx) {
-            let text = app.input_text();
-            lines.push(Line::from(vec![
-                Span::styled("       > ", Style::default().fg(Color::Yellow)),
-                Span::styled(text, Style::default().fg(Color::Yellow)),
-                Span::styled("_", Style::default().fg(Color::Yellow)),
-            ]));
-        }
-    }
-
-    // Apply scroll (clamp and write back so future scroll-up works immediately)
-    let total_lines = lines.len();
-    let visible_height = inner.height as usize;
-    let max_scroll = total_lines.saturating_sub(visible_height);
-    app.diff_scroll = app.diff_scroll.min(max_scroll);
-    let visible_lines: Vec<Line> = lines
-        .into_iter()
-        .skip(app.diff_scroll)
-        .take(visible_height)
-        .collect();
-
-    let paragraph = Paragraph::new(visible_lines);
-    frame.render_widget(paragraph, inner);
-
-    // Render change map (scrollbar with colored change indicators)
-    if total_lines > 0 {
-        render_change_map(
-            frame,
-            &all_diff_lines,
-            total_lines,
-            visible_height,
-            app.diff_scroll,
-            inner,
-        );
-    }
-}
-
-/// Renders a 1-column change map on the right edge of the diff area.
-/// Each row maps proportionally to the full file; additions are green,
-/// deletions are red, and the current viewport is shown as a bright thumb.
-fn render_change_map(
-    frame: &mut Frame,
-    diff_lines: &[&DiffLine],
-    total_rendered: usize,
-    visible_height: usize,
-    scroll: usize,
-    inner: Rect,
-) {
-    let height = inner.height as usize;
-    if height == 0 || diff_lines.is_empty() {
-        return;
-    }
-
-    let col = inner.x + inner.width.saturating_sub(1);
-    let buf = frame.buffer_mut();
-
-    // Thumb range (viewport indicator)
-    let thumb_start = if total_rendered <= visible_height {
-        0
-    } else {
-        scroll * height / total_rendered
-    };
-    let thumb_len = if total_rendered <= visible_height {
-        height
-    } else {
-        (visible_height * height / total_rendered).max(1)
-    };
-    let thumb_end = (thumb_start + thumb_len).min(height);
-
-    for row in 0..height {
-        // Map this gutter row to a range of diff lines and find the most
-        // significant change type (Addition > Deletion > Context).
-        let range_start = row * diff_lines.len() / height;
-        let range_end = ((row + 1) * diff_lines.len() / height).min(diff_lines.len());
-        let mut has_addition = false;
-        let mut has_deletion = false;
-        for i in range_start..range_end.max(range_start + 1) {
-            match diff_lines[i.min(diff_lines.len() - 1)].line_type {
-                LineType::Addition => has_addition = true,
-                LineType::Deletion => has_deletion = true,
-                _ => {}
-            }
-        }
-
-        let is_thumb = row >= thumb_start && row < thumb_end;
-
-        let (ch, fg, bg) = if has_addition {
-            if is_thumb {
-                ("▐", Color::Green, Color::DarkGray)
-            } else {
-                ("▐", Color::Green, Color::Reset)
-            }
-        } else if has_deletion {
-            if is_thumb {
-                ("▐", Color::Red, Color::DarkGray)
-            } else {
-                ("▐", Color::Red, Color::Reset)
-            }
-        } else if is_thumb {
-            ("█", Color::DarkGray, Color::Reset)
-        } else {
-            ("│", Color::Rgb(40, 40, 40), Color::Reset)
-        };
-
-        let y = inner.y + row as u16;
-        if y < inner.y + inner.height {
-            let cell = &mut buf[(col, y)];
-            cell.set_symbol(ch);
-            cell.set_style(Style::default().fg(fg).bg(bg));
-        }
-    }
-}
-
-fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::DarkGray));
-
-    let content = match app.mode {
-        Mode::Normal => {
-            if let Some(ref msg) = app.status_message {
-                msg.clone()
-            } else {
-                let total_comments: usize = app.comments.values().map(|c| c.len()).sum();
-                let summary_indicator = if app.summary.is_empty() {
-                    ""
-                } else {
-                    " | summary: done"
-                };
-                format!(
-                    " Tab: files | j/k: scroll | h/l: pan | s: summary | S: submit | q: quit | {}{}",
-                    total_comments, summary_indicator
-                )
-            }
-        }
-        Mode::Commenting => " typing comment... | Enter: save | Esc: cancel".to_string(),
-        Mode::Summary => format!(
-            " summary: {}_  | Enter: save | Esc: cancel",
-            app.input_text()
-        ),
-    };
-
-    let style = if app.status_message.is_some() && app.mode == Mode::Normal {
-        Style::default().fg(Color::Green)
-    } else {
-        Style::default()
-    };
-
-    let paragraph = Paragraph::new(content)
-        .style(style)
-        .block(block)
-        .wrap(Wrap { trim: true });
-    frame.render_widget(paragraph, area);
+    frame.render_stateful_widget(FileListWidget, file_list_area, app);
+    frame.render_stateful_widget(DiffWidget, diff_area, app);
+    frame.render_widget(StatusBarWidget::new(app), status_area);
 }
 
 /// Shorten a path to fit the sidebar. Shows last dir + filename when possible.
@@ -352,7 +76,7 @@ pub fn diff_area(frame_area: Rect) -> Rect {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::App;
+    use crate::app::{App, Mode};
     use crate::diff::{DiffLine, FileDiff, Hunk, LineType};
     use crate::git::{ChangeType, ChangedFile};
     use ratatui::{backend::TestBackend, buffer::Buffer, Terminal};
@@ -423,7 +147,6 @@ mod tests {
 
     #[test]
     fn short_path_long_no_slash_returns_whole() {
-        // No slash means rsplit('/').next() returns the whole string
         let path = "a_really_long_filename_without_slashes.rs";
         assert_eq!(short_path(path), path);
     }
@@ -437,7 +160,6 @@ mod tests {
 
     #[test]
     fn short_path_19_chars_with_slash_returns_dir_file() {
-        // 19 characters with slashes — shows dir/file
         let path = "abc/defgh/123456789";
         assert_eq!(path.len(), 19);
         assert_eq!(short_path(path), "defgh/123456789");
@@ -472,7 +194,6 @@ mod tests {
     fn diff_area_standard_frame() {
         let frame = Rect::new(0, 0, 80, 24);
         let area = diff_area(frame);
-        // inner rect: inside the diff block borders
         assert!(area.width > 0);
         assert!(area.height > 0);
     }
@@ -488,7 +209,6 @@ mod tests {
     fn diff_area_height_is_frame_minus_status_minus_borders() {
         let frame = Rect::new(0, 0, 80, 24);
         let area = diff_area(frame);
-        // main height = 24 - 3 = 21, inner = 21 - 2 = 19
         assert_eq!(area.height, 24 - 3 - 2);
     }
 

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -1,0 +1,59 @@
+use crate::app::{App, Mode};
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::widgets::{Block, Borders, Paragraph, Widget, Wrap};
+
+pub struct StatusBarWidget<'a> {
+    app: &'a App,
+}
+
+impl<'a> StatusBarWidget<'a> {
+    pub fn new(app: &'a App) -> Self {
+        Self { app }
+    }
+}
+
+impl Widget for StatusBarWidget<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::DarkGray));
+
+        let content = match self.app.mode {
+            Mode::Normal => {
+                if let Some(ref msg) = self.app.status_message {
+                    msg.clone()
+                } else {
+                    let total_comments: usize = self.app.comments.values().map(|c| c.len()).sum();
+                    let summary_indicator = if self.app.summary.is_empty() {
+                        ""
+                    } else {
+                        " | summary: done"
+                    };
+                    format!(
+                        " Tab: files | j/k: scroll | h/l: pan | s: summary | S: submit | q: quit | {}{}",
+                        total_comments, summary_indicator
+                    )
+                }
+            }
+            Mode::Commenting => " typing comment... | Enter: save | Esc: cancel".to_string(),
+            Mode::Summary => format!(
+                " summary: {}_  | Enter: save | Esc: cancel",
+                self.app.input_text()
+            ),
+        };
+
+        let style = if self.app.status_message.is_some() && self.app.mode == Mode::Normal {
+            Style::default().fg(Color::Green)
+        } else {
+            Style::default()
+        };
+
+        Paragraph::new(content)
+            .style(style)
+            .block(block)
+            .wrap(Wrap { trim: true })
+            .render(area, buf);
+    }
+}

--- a/tests/git_test.rs
+++ b/tests/git_test.rs
@@ -1,11 +1,7 @@
-use std::process::Command;
+use git2::Repository;
 
 #[test]
-#[ignore] // requires local main branch; skipped in CI
-fn test_git_diff_stat_parses() {
-    let output = Command::new("git")
-        .args(["diff", "--stat", "main...HEAD"])
-        .output()
-        .expect("git command failed");
-    assert!(output.status.success());
+fn repo_discovers_from_cwd() {
+    let repo = Repository::discover(".");
+    assert!(repo.is_ok(), "Should find a git repository from cwd");
 }


### PR DESCRIPTION
## Summary
- Breaks monolithic `ui.rs` (731 lines) into `ui/mod.rs`, `ui/diff.rs`, `ui/file_list.rs`, `ui/status_bar.rs` with proper `Widget`/`StatefulWidget` trait implementations
- Replaces all `Command::new("git")` shell-outs with `git2` library — untracked files now show up automatically with full diff content
- Adds 18 proper git tests using temp repos via `tempfile` + `git2::Repository::init`

## Test plan
- [x] All 128 tests pass locally
- [x] `cargo clippy` clean, `cargo fmt` clean
- [ ] CI passes
- [ ] Manual test: `cargo run` shows all files including untracked, diffs render correctly

Closes #5, closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)