### PR TITLE
Add syntax highlighting to diff view

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2,6 +2,8 @@ use crate::diff::FileDiff;
 use crate::git::ChangedFile;
 use ratatui::widgets::ListState;
 use std::collections::HashMap;
+use syntect::highlighting::ThemeSet;
+use syntect::parsing::SyntaxSet;
 use tui_textarea::{CursorMove, TextArea};
 
 #[derive(Debug, Clone)]
@@ -24,6 +26,8 @@ pub struct App {
     pub commenting_line: Option<usize>,
     pub should_quit: bool,
     pub status_message: Option<String>,
+    pub syntax_set: SyntaxSet,
+    pub theme_set: ThemeSet,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -53,6 +57,8 @@ impl App {
             commenting_line: None,
             should_quit: false,
             status_message: None,
+            syntax_set: SyntaxSet::load_defaults_newlines(),
+            theme_set: ThemeSet::load_defaults(),
         }
     }
 

--- a/src/ui/diff.rs
+++ b/src/ui/diff.rs
@@ -6,8 +6,91 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, StatefulWidget, Widget};
+use syntect::easy::HighlightLines;
+use syntect::highlighting::Style as SynStyle;
 
 pub struct DiffWidget;
+
+/// Convert a syntect color to a ratatui color.
+fn syn_to_rat_fg(c: syntect::highlighting::Color) -> Color {
+    Color::Rgb(c.r, c.g, c.b)
+}
+
+/// Build a line number span.
+fn line_no_span(diff_line: &DiffLine) -> Span<'static> {
+    let text = match diff_line.line_type {
+        LineType::HunkHeader => "   ".to_string(),
+        _ => {
+            let n = diff_line.new_line_no.or(diff_line.old_line_no);
+            n.map_or("   ".to_string(), |n| format!("{:>3}", n))
+        }
+    };
+    Span::styled(format!("{} ", text), Style::default().fg(Color::DarkGray))
+}
+
+/// Build spans for a syntax-highlighted content line with a diff prefix.
+fn highlighted_spans(
+    prefix: &str,
+    content: &str,
+    hscroll: usize,
+    regions: &[(SynStyle, &str)],
+    bg: Option<Color>,
+) -> Vec<Span<'static>> {
+    let mut spans = Vec::new();
+
+    // Prefix span (+/-/space)
+    let prefix_style = match prefix {
+        "+" => Style::default().fg(Color::Green),
+        "-" => Style::default().fg(Color::Red),
+        _ => Style::default().fg(Color::DarkGray),
+    };
+    let prefix_style = if let Some(bg) = bg {
+        prefix_style.bg(bg)
+    } else {
+        prefix_style
+    };
+    spans.push(Span::styled(prefix.to_string(), prefix_style));
+
+    // Map syntax regions onto the visible (hscroll-adjusted) content
+    let visible: String = content.chars().skip(hscroll).collect();
+    if visible.is_empty() {
+        return spans;
+    }
+
+    // Walk through regions, skipping hscroll chars
+    let mut chars_skipped = 0;
+    for (style, text) in regions {
+        let region_len = text.chars().count();
+        if chars_skipped + region_len <= hscroll {
+            chars_skipped += region_len;
+            continue;
+        }
+
+        let skip_in_region = hscroll.saturating_sub(chars_skipped);
+        let visible_text: String = text.chars().skip(skip_in_region).collect();
+        chars_skipped += skip_in_region;
+
+        if !visible_text.is_empty() {
+            let mut span_style = Style::default().fg(syn_to_rat_fg(style.foreground));
+            if let Some(bg) = bg {
+                span_style = span_style.bg(bg);
+            }
+            spans.push(Span::styled(visible_text, span_style));
+        }
+        chars_skipped += region_len - skip_in_region;
+    }
+
+    spans
+}
+
+/// Build spans for a line without syntax highlighting (fallback).
+fn plain_spans(prefix: &str, content: &str, hscroll: usize, style: Style) -> Vec<Span<'static>> {
+    let visible_content: String = content.chars().skip(hscroll).collect();
+    vec![Span::styled(
+        format!("{}{}", prefix, visible_content),
+        style,
+    )]
+}
 
 impl StatefulWidget for DiffWidget {
     type State = App;
@@ -29,6 +112,15 @@ impl StatefulWidget for DiffWidget {
             return;
         };
 
+        // Set up syntax highlighter based on file extension
+        let highlighter = state.current_file.as_ref().and_then(|path| {
+            let ext = path.rsplit('.').next()?;
+            let syntax = state.syntax_set.find_syntax_by_extension(ext)?;
+            let theme = &state.theme_set.themes["base16-ocean.dark"];
+            Some(HighlightLines::new(syntax, theme))
+        });
+        let mut highlighter = highlighter;
+
         let mut lines: Vec<Line> = Vec::new();
         let file_comments = state
             .current_file
@@ -38,37 +130,78 @@ impl StatefulWidget for DiffWidget {
         let all_diff_lines: Vec<_> = diff.hunks.iter().flat_map(|h| h.lines.iter()).collect();
 
         for (idx, diff_line) in all_diff_lines.iter().enumerate() {
-            let (style, prefix) = match diff_line.line_type {
-                LineType::Addition => (Style::default().fg(Color::Green), "+"),
-                LineType::Deletion => (Style::default().fg(Color::Red), "-"),
-                LineType::Context => (Style::default().fg(Color::White), " "),
-                LineType::HunkHeader => (
-                    Style::default()
-                        .fg(Color::Cyan)
-                        .add_modifier(Modifier::BOLD),
-                    "",
-                ),
-            };
-
-            let line_no = match diff_line.line_type {
-                LineType::HunkHeader => "   ".to_string(),
-                _ => {
-                    let n = diff_line.new_line_no.or(diff_line.old_line_no);
-                    n.map_or("   ".to_string(), |n| format!("{:>3}", n))
-                }
-            };
-
-            // Replace tabs with spaces and apply horizontal scroll
             let content = diff_line.content.replace('\t', "    ");
-            let visible_content: String = content.chars().skip(state.diff_hscroll).collect();
 
-            lines.push(Line::from(vec![
-                Span::styled(
-                    format!("{} ", line_no),
-                    Style::default().fg(Color::DarkGray),
-                ),
-                Span::styled(format!("{}{}", prefix, visible_content), style),
-            ]));
+            let mut spans = vec![line_no_span(diff_line)];
+
+            match diff_line.line_type {
+                LineType::HunkHeader => {
+                    spans.push(Span::styled(
+                        content.clone(),
+                        Style::default()
+                            .fg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD),
+                    ));
+                    // Reset highlighter state at hunk boundaries
+                    if let Some(ref mut h) = highlighter {
+                        // Re-create to reset parse state
+                        if let Some(path) = &state.current_file {
+                            if let Some(ext) = path.rsplit('.').next() {
+                                if let Some(syntax) = state.syntax_set.find_syntax_by_extension(ext)
+                                {
+                                    let theme = &state.theme_set.themes["base16-ocean.dark"];
+                                    *h = HighlightLines::new(syntax, theme);
+                                }
+                            }
+                        }
+                    }
+                }
+                LineType::Addition | LineType::Deletion | LineType::Context => {
+                    let prefix = match diff_line.line_type {
+                        LineType::Addition => "+",
+                        LineType::Deletion => "-",
+                        _ => " ",
+                    };
+
+                    let bg = match diff_line.line_type {
+                        LineType::Addition => Some(Color::Rgb(0, 40, 0)),
+                        LineType::Deletion => Some(Color::Rgb(40, 0, 0)),
+                        _ => None,
+                    };
+
+                    // Feed the line to the highlighter (needs trailing newline)
+                    let line_for_highlight = format!("{}\n", content);
+                    if let Some(ref mut h) = highlighter {
+                        if let Ok(regions) =
+                            h.highlight_line(&line_for_highlight, &state.syntax_set)
+                        {
+                            spans.extend(highlighted_spans(
+                                prefix,
+                                &content,
+                                state.diff_hscroll,
+                                &regions,
+                                bg,
+                            ));
+                        } else {
+                            let style = match diff_line.line_type {
+                                LineType::Addition => Style::default().fg(Color::Green),
+                                LineType::Deletion => Style::default().fg(Color::Red),
+                                _ => Style::default().fg(Color::White),
+                            };
+                            spans.extend(plain_spans(prefix, &content, state.diff_hscroll, style));
+                        }
+                    } else {
+                        let style = match diff_line.line_type {
+                            LineType::Addition => Style::default().fg(Color::Green),
+                            LineType::Deletion => Style::default().fg(Color::Red),
+                            _ => Style::default().fg(Color::White),
+                        };
+                        spans.extend(plain_spans(prefix, &content, state.diff_hscroll, style));
+                    }
+                }
+            }
+
+            lines.push(Line::from(spans));
 
             // Render inline comments for this line
             if let Some(comments) = file_comments {
@@ -155,8 +288,6 @@ fn render_change_map(
     let thumb_end = (thumb_start + thumb_len).min(height);
 
     for row in 0..height {
-        // Map this gutter row to a range of diff lines and find the most
-        // significant change type (Addition > Deletion > Context).
         let range_start = row * diff_lines.len() / height;
         let range_end = ((row + 1) * diff_lines.len() / height).min(diff_lines.len());
         let mut has_addition = false;


### PR DESCRIPTION
## Summary
- Syntax-highlighted diffs using syntect with base16-ocean.dark theme
- Additions get subtle dark green background, deletions dark red, with syntax colors layered on top
- Falls back to plain diff coloring for unknown file types
- Highlighter resets at hunk boundaries for correct incremental parsing

## Test plan
- [x] All 128 tests pass
- [x] Clippy clean
- [ ] CI passes
- [ ] Manual: verify syntax colors render on .rs, .toml, .yml files

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)