### PR TITLE
feat: edit and delete existing comments (#13)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -25,6 +25,8 @@ pub struct App {
     pub diff_scroll: usize,
     pub diff_hscroll: usize,
     pub commenting_line: Option<usize>,
+    /// When editing an existing comment, tracks (file_path, index in comments vec).
+    pub editing_comment: Option<(String, usize)>,
     pub should_quit: bool,
     pub status_message: Option<String>,
     pub syntax_set: SyntaxSet,
@@ -57,6 +59,7 @@ impl App {
             diff_scroll: 0,
             diff_hscroll: 0,
             commenting_line: None,
+            editing_comment: None,
             should_quit: false,
             status_message: None,
             syntax_set: SyntaxSet::load_defaults_newlines(),
@@ -111,8 +114,26 @@ impl App {
     }
 
     pub fn submit_comment(&mut self) {
-        if let (Some(line_idx), Some(file)) = (self.commenting_line, &self.current_file) {
-            let text = self.input_text();
+        let text = self.input_text();
+        if let Some((ref file, idx)) = self.editing_comment {
+            // Editing existing comment
+            if text.is_empty() {
+                // Empty text deletes the comment
+                if let Some(comments) = self.comments.get_mut(file) {
+                    if idx < comments.len() {
+                        comments.remove(idx);
+                    }
+                    if comments.is_empty() {
+                        self.comments.remove(file);
+                    }
+                }
+            } else if let Some(comments) = self.comments.get_mut(file) {
+                if idx < comments.len() {
+                    comments[idx].text = text;
+                }
+            }
+        } else if let (Some(line_idx), Some(file)) = (self.commenting_line, &self.current_file) {
+            // New comment
             if !text.is_empty() {
                 let comment = ReviewComment {
                     line_index: line_idx,
@@ -123,6 +144,24 @@ impl App {
         }
         self.clear_input();
         self.commenting_line = None;
+        self.editing_comment = None;
+        self.mode = Mode::Normal;
+    }
+
+    pub fn delete_comment(&mut self) {
+        if let Some((ref file, idx)) = self.editing_comment {
+            if let Some(comments) = self.comments.get_mut(file) {
+                if idx < comments.len() {
+                    comments.remove(idx);
+                }
+                if comments.is_empty() {
+                    self.comments.remove(file);
+                }
+            }
+        }
+        self.clear_input();
+        self.commenting_line = None;
+        self.editing_comment = None;
         self.mode = Mode::Normal;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,9 +140,13 @@ fn handle_commenting_key(app: &mut App, key: KeyEvent) {
             }
         }
         (KeyCode::Enter, _) => app.submit_comment(),
+        (KeyCode::Char('d'), m) if m.contains(KeyModifiers::CONTROL) => {
+            app.delete_comment();
+        }
         (KeyCode::Esc, _) => {
             app.clear_input();
             app.commenting_line = None;
+            app.editing_comment = None;
             app.mode = Mode::Normal;
         }
         _ => {
@@ -223,9 +227,21 @@ fn handle_mouse_click(app: &mut App, col: u16, row: u16, frame_size: ratatui::la
     {
         let clicked_row = (row - diff_inner.y) as usize + app.diff_scroll;
         if let Some(line_idx) = map_row_to_diff_line(app, clicked_row) {
+            // Check if there's an existing comment on this line to edit
+            let existing = app.current_file.as_ref().and_then(|file| {
+                let comments = app.comments.get(file)?;
+                let idx = comments.iter().position(|c| c.line_index == line_idx)?;
+                Some((file.clone(), idx, comments[idx].text.clone()))
+            });
             app.commenting_line = Some(line_idx);
             app.mode = Mode::Commenting;
-            app.start_input("");
+            if let Some((file, idx, text)) = existing {
+                app.editing_comment = Some((file, idx));
+                app.start_input(&text);
+            } else {
+                app.editing_comment = None;
+                app.start_input("");
+            }
         }
     }
 }

--- a/src/ui/diff.rs
+++ b/src/ui/diff.rs
@@ -224,8 +224,13 @@ impl StatefulWidget for DiffWidget {
                     .as_ref()
                     .map(|ta| ta.cursor())
                     .unwrap_or((0, 0));
+                let hint = if state.editing_comment.is_some() {
+                    "⏎ save │ Ctrl+D delete │ Esc cancel"
+                } else {
+                    "⏎ save │ Alt+⏎ newline │ Esc cancel"
+                };
                 let card = CommentCard::new(&text, Color::Yellow, card_width)
-                    .hint("⏎ save │ Alt+⏎ newline │ Esc cancel")
+                    .hint(hint)
                     .cursor(crow, ccol, cursor_visible);
                 lines.extend(card.to_lines());
             }


### PR DESCRIPTION
## Summary
- Click a line with an existing comment to edit it (pre-filled textarea)
- Ctrl+D deletes a comment while editing
- Clearing text + Enter also deletes
- Contextual hint: shows "Ctrl+D delete" when editing, "Alt+⏎ newline" when creating

## Test plan
- [x] All 128 tests passing
- [x] Existing comment submission tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)