### PR TITLE
feat: multi-commit review with commit selection (#3)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use crate::diff::FileDiff;
-use crate::git::ChangedFile;
+use crate::git::{ChangedFile, CommitInfo};
+use git2::Oid;
 use ratatui::widgets::ListState;
 use std::collections::HashMap;
 use std::time::Instant;
@@ -32,6 +33,14 @@ pub struct App {
     pub syntax_set: SyntaxSet,
     pub theme_set: ThemeSet,
     pub cursor_blink_start: Instant,
+    /// Commits between main and HEAD, newest first.
+    pub commits: Vec<CommitInfo>,
+    /// Which commits are selected (by index into `commits`). All selected by default.
+    pub selected_commits: Vec<bool>,
+    pub commit_list_state: ListState,
+    /// The OID of the main branch commit (base for diffs).
+    pub main_oid: Option<Oid>,
+    pub file_scroll: usize,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -65,6 +74,11 @@ impl App {
             syntax_set: SyntaxSet::load_defaults_newlines(),
             theme_set: ThemeSet::load_defaults(),
             cursor_blink_start: Instant::now(),
+            commits: Vec::new(),
+            selected_commits: Vec::new(),
+            commit_list_state: ListState::default(),
+            main_oid: None,
+            file_scroll: 0,
         }
     }
 
@@ -173,6 +187,106 @@ impl App {
 
     pub fn file_comment_count(&self, path: &str) -> usize {
         self.comments.get(path).map_or(0, |c| c.len())
+    }
+
+    pub fn set_commits(&mut self, commits: Vec<CommitInfo>, main_oid: Oid) {
+        let count = commits.len();
+        self.commits = commits;
+        self.selected_commits = vec![true; count];
+        self.main_oid = Some(main_oid);
+        if count > 0 {
+            self.commit_list_state.select(Some(0));
+        }
+    }
+
+    pub fn toggle_commit(&mut self, index: usize) {
+        if index < self.selected_commits.len() {
+            self.selected_commits[index] = !self.selected_commits[index];
+        }
+    }
+
+    /// Returns the "from" OID for diffing based on selected commits.
+    /// This is the parent of the oldest selected commit, or main if the oldest is selected.
+    /// Returns None if no commits are selected (falls back to main diff).
+    pub fn diff_from_oid(&self) -> Option<Oid> {
+        if self.commits.is_empty() {
+            return self.main_oid;
+        }
+        // If no commits selected, diff everything against main
+        if !self.selected_commits.iter().any(|&s| s) {
+            return self.main_oid;
+        }
+        // Find the oldest selected commit (last in vec since newest-first)
+        let oldest_idx = self
+            .selected_commits
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, &s)| s)
+            .map(|(i, _)| i)?;
+        // The "from" is the parent of the oldest selected commit,
+        // which is the commit just after it in our list (older), or main_oid
+        if oldest_idx + 1 < self.commits.len() {
+            Some(self.commits[oldest_idx + 1].id)
+        } else {
+            self.main_oid
+        }
+    }
+
+    /// Returns the "to" OID for diffing. None means diff to working directory.
+    /// If the newest selected commit is not the first one, we diff up to that commit.
+    pub fn diff_to_oid(&self) -> Option<Oid> {
+        if self.commits.is_empty() {
+            return None; // working dir
+        }
+        if !self.selected_commits.iter().any(|&s| s) {
+            return None; // working dir
+        }
+        // Find newest selected commit
+        let newest_idx = self.selected_commits.iter().position(|&s| s)?;
+        if newest_idx == 0 {
+            // Newest commit selected — include working dir changes
+            None
+        } else {
+            Some(self.commits[newest_idx].id)
+        }
+    }
+
+    /// Reload file list based on current commit selection.
+    pub fn reload_files_for_selection(&mut self) {
+        let from = self.diff_from_oid();
+        let to = self.diff_to_oid();
+        if let Some(from) = from {
+            if let Ok(files) = crate::git::get_changed_files_for_range(from, to) {
+                self.files = files;
+                self.file_list_state = ListState::default();
+                if !self.files.is_empty() {
+                    self.file_list_state.select(Some(0));
+                }
+                self.current_diff = None;
+                self.current_file = None;
+                self.file_scroll = 0;
+            }
+        }
+    }
+
+    /// Select a file using the current commit range for diff.
+    pub fn select_file_for_range(&mut self, index: usize) {
+        if index < self.files.len() {
+            let path = self.files[index].path.clone();
+            let from = self.diff_from_oid();
+            let to = self.diff_to_oid();
+            let diff = from.and_then(|f| {
+                crate::git::get_file_diff_for_range(&path, f, to)
+                    .ok()
+                    .map(|raw| crate::diff::parse_diff(&raw))
+            });
+            self.file_list_state.select(Some(index));
+            self.current_file = Some(path);
+            self.current_diff = diff;
+            self.diff_scroll = 0;
+            self.diff_hscroll = 0;
+        }
     }
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use git2::{Delta, Diff, DiffOptions, Patch, Repository};
+use git2::{Delta, Diff, DiffOptions, Oid, Patch, Repository};
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -8,6 +8,13 @@ pub struct ChangedFile {
     pub change_type: ChangeType,
     pub additions: usize,
     pub deletions: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct CommitInfo {
+    pub id: Oid,
+    pub short_id: String,
+    pub message: String,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -22,12 +29,106 @@ fn open_repo() -> Result<Repository> {
     Repository::discover(".").context("Not a git repository")
 }
 
-fn main_tree(repo: &Repository) -> Result<git2::Tree<'_>> {
+fn main_commit(repo: &Repository) -> Result<git2::Commit<'_>> {
     let branch = repo
         .find_branch("main", git2::BranchType::Local)
         .context("Could not find 'main' branch")?;
-    let commit = branch.get().peel_to_commit()?;
-    Ok(commit.tree()?)
+    Ok(branch.get().peel_to_commit()?)
+}
+
+fn main_tree(repo: &Repository) -> Result<git2::Tree<'_>> {
+    Ok(main_commit(repo)?.tree()?)
+}
+
+/// List commits from HEAD back to (but not including) the main branch commit.
+/// Returns newest commit first.
+pub(crate) fn list_commits(repo: &Repository) -> Result<Vec<CommitInfo>> {
+    let main = main_commit(repo)?;
+    let head = repo.head()?.peel_to_commit()?;
+
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push(head.id())?;
+    revwalk.hide(main.id())?;
+    revwalk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::TIME)?;
+
+    let mut commits = Vec::new();
+    for oid in revwalk {
+        let oid = oid?;
+        let commit = repo.find_commit(oid)?;
+        let short_id = format!("{}", &oid.to_string()[..7]);
+        let message = commit
+            .message()
+            .unwrap_or("")
+            .lines()
+            .next()
+            .unwrap_or("")
+            .to_string();
+        commits.push(CommitInfo {
+            id: oid,
+            short_id,
+            message,
+        });
+    }
+    Ok(commits)
+}
+
+/// Compute diff between two tree-ish objects (commits).
+/// If `to_oid` is None, diffs to the working directory.
+pub(crate) fn diff_commit_range(
+    repo: &Repository,
+    from_oid: Oid,
+    to_oid: Option<Oid>,
+    context_lines: u32,
+) -> Result<Diff<'_>> {
+    let from_commit = repo.find_commit(from_oid)?;
+    let from_tree = from_commit.tree()?;
+    let mut opts = DiffOptions::new();
+    opts.context_lines(context_lines);
+    opts.include_untracked(true);
+    opts.show_untracked_content(true);
+    opts.recurse_untracked_dirs(true);
+
+    match to_oid {
+        Some(to) => {
+            let to_commit = repo.find_commit(to)?;
+            let to_tree = to_commit.tree()?;
+            repo.diff_tree_to_tree(Some(&from_tree), Some(&to_tree), Some(&mut opts))
+                .context("Failed to diff commit range")
+        }
+        None => repo
+            .diff_tree_to_workdir_with_index(Some(&from_tree), Some(&mut opts))
+            .context("Failed to diff to working directory"),
+    }
+}
+
+/// Compute diff for a specific file within a commit range.
+pub(crate) fn diff_commit_range_file<'a>(
+    repo: &'a Repository,
+    from_oid: Oid,
+    to_oid: Option<Oid>,
+    path: &str,
+    context_lines: u32,
+) -> Result<Diff<'a>> {
+    let from_commit = repo.find_commit(from_oid)?;
+    let from_tree = from_commit.tree()?;
+    let mut opts = DiffOptions::new();
+    opts.pathspec(path);
+    opts.context_lines(context_lines);
+    opts.include_untracked(true);
+    opts.show_untracked_content(true);
+    opts.recurse_untracked_dirs(true);
+
+    match to_oid {
+        Some(to) => {
+            let to_commit = repo.find_commit(to)?;
+            let to_tree = to_commit.tree()?;
+            repo.diff_tree_to_tree(Some(&from_tree), Some(&to_tree), Some(&mut opts))
+                .context("Failed to diff file in commit range")
+        }
+        None => repo
+            .diff_tree_to_workdir_with_index(Some(&from_tree), Some(&mut opts))
+            .context("Failed to diff file to working directory"),
+    }
 }
 
 fn diff_against_main(repo: &Repository, context_lines: u32) -> Result<Diff<'_>> {
@@ -107,6 +208,26 @@ pub fn get_changed_files() -> Result<Vec<ChangedFile>> {
 }
 
 #[cfg(not(tarpaulin_include))]
+pub fn get_changed_files_for_range(from: Oid, to: Option<Oid>) -> Result<Vec<ChangedFile>> {
+    let repo = open_repo()?;
+    let diff = diff_commit_range(&repo, from, to, 3)?;
+    Ok(changed_files_from_diff(&diff))
+}
+
+#[cfg(not(tarpaulin_include))]
+pub fn get_commits() -> Result<Vec<CommitInfo>> {
+    let repo = open_repo()?;
+    list_commits(&repo)
+}
+
+#[cfg(not(tarpaulin_include))]
+pub fn get_main_oid() -> Result<Oid> {
+    let repo = open_repo()?;
+    let oid = main_commit(&repo)?.id();
+    Ok(oid)
+}
+
+#[cfg(not(tarpaulin_include))]
 pub fn get_file_diff(path: &str) -> Result<String> {
     let repo = open_repo()?;
     let tree = main_tree(&repo)?;
@@ -127,6 +248,18 @@ pub fn get_file_diff(path: &str) -> Result<String> {
         .diff_tree_to_workdir_with_index(Some(&tree), Some(&mut opts))
         .context("Failed to compute file diff")?;
 
+    format_diff_patch(&diff)
+}
+
+#[cfg(not(tarpaulin_include))]
+pub fn get_file_diff_for_range(path: &str, from: Oid, to: Option<Oid>) -> Result<String> {
+    let repo = open_repo()?;
+
+    let line_count = std::fs::read_to_string(path)
+        .map(|s| s.lines().count())
+        .unwrap_or(0) as u32;
+
+    let diff = diff_commit_range_file(&repo, from, to, path, line_count)?;
     format_diff_patch(&diff)
 }
 
@@ -376,5 +509,78 @@ mod tests {
         // Context line for unchanged "hello" and addition of "new line"
         assert!(patch.contains(" hello"));
         assert!(patch.contains("+new line"));
+    }
+
+    // ── commit helpers ──────────────────────────────────────────────
+
+    /// Create a commit on HEAD in the given repo.
+    fn make_commit(dir: &std::path::Path, repo: &Repository, filename: &str, content: &str) {
+        fs::write(dir.join(filename), content).unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new(filename)).unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_oid).unwrap();
+        let sig = repo.signature().unwrap();
+        let parent = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.commit(
+            Some("HEAD"),
+            &sig,
+            &sig,
+            &format!("add {}", filename),
+            &tree,
+            &[&parent],
+        )
+        .unwrap();
+    }
+
+    // ── list_commits ────────────────────────────────────────────────
+
+    #[test]
+    fn list_commits_no_commits_beyond_main() {
+        let (_dir, repo) = setup_repo();
+        let commits = list_commits(&repo).unwrap();
+        assert!(commits.is_empty());
+    }
+
+    #[test]
+    fn list_commits_returns_commits_after_main() {
+        let (dir, repo) = setup_repo();
+        make_commit(dir.path(), &repo, "a.txt", "aaa\n");
+        make_commit(dir.path(), &repo, "b.txt", "bbb\n");
+
+        let commits = list_commits(&repo).unwrap();
+        assert_eq!(commits.len(), 2);
+        // Newest first
+        assert!(commits[0].message.contains("add b.txt"));
+        assert!(commits[1].message.contains("add a.txt"));
+        assert_eq!(commits[0].short_id.len(), 7);
+    }
+
+    // ── diff_commit_range ───────────────────────────────────────────
+
+    #[test]
+    fn diff_commit_range_between_two_commits() {
+        let (dir, repo) = setup_repo();
+        make_commit(dir.path(), &repo, "a.txt", "aaa\n");
+        let commits = list_commits(&repo).unwrap();
+        let main_oid = main_commit(&repo).unwrap().id();
+
+        let diff = diff_commit_range(&repo, main_oid, Some(commits[0].id), 3).unwrap();
+        let files = changed_files_from_diff(&diff);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "a.txt");
+    }
+
+    #[test]
+    fn diff_commit_range_to_working_dir() {
+        let (dir, repo) = setup_repo();
+        fs::write(dir.path().join("initial.txt"), "changed\n").unwrap();
+        let main_oid = main_commit(&repo).unwrap().id();
+
+        let diff = diff_commit_range(&repo, main_oid, None, 3).unwrap();
+        let files = changed_files_from_diff(&diff);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].change_type, ChangeType::Modified);
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -55,7 +55,7 @@ pub(crate) fn list_commits(repo: &Repository) -> Result<Vec<CommitInfo>> {
     for oid in revwalk {
         let oid = oid?;
         let commit = repo.find_commit(oid)?;
-        let short_id = format!("{}", &oid.to_string()[..7]);
+        let short_id = oid.to_string()[..7].to_string();
         let message = commit
             .message()
             .unwrap_or("")

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,11 @@ fn main() -> Result<()> {
     let mut terminal = ratatui::init();
     let mut app = App::new(files);
 
+    // Load commits and main OID
+    if let (Ok(commits), Ok(main_oid)) = (git::get_commits(), git::get_main_oid()) {
+        app.set_commits(commits, main_oid);
+    }
+
     if !app.files.is_empty() {
         app.select_file(0);
     }
@@ -110,7 +115,7 @@ fn handle_normal_key(app: &mut App, code: KeyCode) {
                     0
                 }
             });
-            app.select_file(next);
+            select_file(app, next);
         }
         KeyCode::BackTab => {
             let prev = app.file_list_state.selected().map_or(0, |i| {
@@ -120,11 +125,19 @@ fn handle_normal_key(app: &mut App, code: KeyCode) {
                     i - 1
                 }
             });
-            app.select_file(prev);
+            select_file(app, prev);
         }
         KeyCode::Char('r') => {
-            if let Ok(files) = git::get_changed_files() {
-                refresh_file_list(app, files);
+            if app.commits.is_empty() {
+                if let Ok(files) = git::get_changed_files() {
+                    refresh_file_list(app, files);
+                }
+            } else {
+                // Reload commits and files
+                if let (Ok(commits), Ok(main_oid)) = (git::get_commits(), git::get_main_oid()) {
+                    app.set_commits(commits, main_oid);
+                }
+                app.reload_files_for_selection();
             }
         }
         _ => {}
@@ -211,9 +224,29 @@ fn handle_mouse_click(app: &mut App, col: u16, row: u16, frame_size: ratatui::la
         && row > file_area.y
         && row < file_area.y + file_area.height - 1
     {
-        let index = (row - file_area.y - 1) as usize;
+        let index = (row - file_area.y - 1) as usize + app.file_scroll;
         if index < app.files.len() {
-            app.select_file(index);
+            if app.commits.is_empty() {
+                app.select_file(index);
+            } else {
+                app.select_file_for_range(index);
+            }
+        }
+        return;
+    }
+
+    // Check if click is in commit list
+    let commit_area = ui::commit_list_area(frame_size);
+    if col >= commit_area.x
+        && col < commit_area.x + commit_area.width
+        && row > commit_area.y
+        && row < commit_area.y + commit_area.height - 1
+    {
+        let index = (row - commit_area.y - 1) as usize;
+        if index < app.commits.len() {
+            app.commit_list_state.select(Some(index));
+            app.toggle_commit(index);
+            app.reload_files_for_selection();
         }
         return;
     }
@@ -243,6 +276,15 @@ fn handle_mouse_click(app: &mut App, col: u16, row: u16, frame_size: ratatui::la
                 app.start_input("");
             }
         }
+    }
+}
+
+/// Select a file using commit-range-aware or plain method.
+fn select_file(app: &mut App, index: usize) {
+    if app.commits.is_empty() {
+        app.select_file(index);
+    } else {
+        app.select_file_for_range(index);
     }
 }
 
@@ -316,15 +358,6 @@ mod tests {
         Event::Key(KeyEvent {
             code,
             modifiers: KeyModifiers::NONE,
-            kind: KeyEventKind::Press,
-            state: KeyEventState::NONE,
-        })
-    }
-
-    fn ctrl_key_event(code: KeyCode) -> Event {
-        Event::Key(KeyEvent {
-            code,
-            modifiers: KeyModifiers::CONTROL,
             kind: KeyEventKind::Press,
             state: KeyEventState::NONE,
         })

--- a/src/ui/commit_list.rs
+++ b/src/ui/commit_list.rs
@@ -1,0 +1,60 @@
+use crate::app::App;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, StatefulWidget};
+
+pub struct CommitListWidget;
+
+impl StatefulWidget for CommitListWidget {
+    type State = App;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut App) {
+        let items: Vec<ListItem> = state
+            .commits
+            .iter()
+            .enumerate()
+            .map(|(i, c)| {
+                let selected = state.selected_commits.get(i).copied().unwrap_or(false);
+                let check = if selected { "●" } else { "○" };
+                let check_color = if selected {
+                    Color::Green
+                } else {
+                    Color::DarkGray
+                };
+
+                let msg: String = c.message.chars().take(16).collect();
+
+                let line = Line::from(vec![
+                    Span::styled(format!("{} ", check), Style::default().fg(check_color)),
+                    Span::styled(
+                        format!("{} ", c.short_id),
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::DIM),
+                    ),
+                    Span::raw(msg),
+                ]);
+
+                ListItem::new(line)
+            })
+            .collect();
+
+        let title = format!(" Commits ({}) ", state.commits.len());
+        let list = List::new(items)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(title)
+                    .border_style(Style::default().fg(Color::DarkGray)),
+            )
+            .highlight_style(
+                Style::default()
+                    .bg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD),
+            );
+
+        StatefulWidget::render(list, area, buf, &mut state.commit_list_state);
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,27 +1,36 @@
 mod comment_card;
+mod commit_list;
 mod diff;
 mod file_list;
 mod status_bar;
 
 use crate::app::App;
+use commit_list::CommitListWidget;
 use diff::DiffWidget;
 use file_list::FileListWidget;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::Frame;
 use status_bar::StatusBarWidget;
 
-/// Width of the file list sidebar
-const FILE_LIST_WIDTH: u16 = 22;
+/// Width of the sidebar (file list + commit list)
+const SIDEBAR_WIDTH: u16 = 28;
+/// Height of the commit list pane
+const COMMIT_LIST_HEIGHT: u16 = 10;
 
 pub fn render(frame: &mut Frame, app: &mut App) {
     let [main_area, status_area] =
         Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).areas(frame.area());
 
-    let [diff_area, file_list_area] =
-        Layout::horizontal([Constraint::Fill(1), Constraint::Length(FILE_LIST_WIDTH)])
+    let [diff_area, sidebar_area] =
+        Layout::horizontal([Constraint::Fill(1), Constraint::Length(SIDEBAR_WIDTH)])
             .areas(main_area);
 
-    frame.render_stateful_widget(FileListWidget, file_list_area, app);
+    let [files_area, commits_area] =
+        Layout::vertical([Constraint::Fill(1), Constraint::Length(COMMIT_LIST_HEIGHT)])
+            .areas(sidebar_area);
+
+    frame.render_stateful_widget(FileListWidget, files_area, app);
+    frame.render_stateful_widget(CommitListWidget, commits_area, app);
     frame.render_stateful_widget(DiffWidget, diff_area, app);
     frame.render_widget(StatusBarWidget::new(app), status_area);
 }
@@ -45,16 +54,27 @@ pub(crate) fn short_path(path: &str) -> &str {
     path.rsplit('/').next().unwrap_or(path)
 }
 
-/// Returns the area occupied by the file list panel.
-pub fn file_list_area(frame_area: Rect) -> Rect {
+/// Compute sidebar layout areas.
+fn sidebar_areas(frame_area: Rect) -> (Rect, Rect) {
     let [main_area, _status] =
         Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).areas(frame_area);
-
-    let [_diff, file_list] =
-        Layout::horizontal([Constraint::Fill(1), Constraint::Length(FILE_LIST_WIDTH)])
+    let [_diff, sidebar] =
+        Layout::horizontal([Constraint::Fill(1), Constraint::Length(SIDEBAR_WIDTH)])
             .areas(main_area);
+    let [files, commits] =
+        Layout::vertical([Constraint::Fill(1), Constraint::Length(COMMIT_LIST_HEIGHT)])
+            .areas(sidebar);
+    (files, commits)
+}
 
-    file_list
+/// Returns the area occupied by the file list panel.
+pub fn file_list_area(frame_area: Rect) -> Rect {
+    sidebar_areas(frame_area).0
+}
+
+/// Returns the area occupied by the commit list panel.
+pub fn commit_list_area(frame_area: Rect) -> Rect {
+    sidebar_areas(frame_area).1
 }
 
 /// Returns the inner area of the diff panel (inside borders).
@@ -62,8 +82,8 @@ pub fn diff_area(frame_area: Rect) -> Rect {
     let [main_area, _status] =
         Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).areas(frame_area);
 
-    let [diff, _file_list] =
-        Layout::horizontal([Constraint::Fill(1), Constraint::Length(FILE_LIST_WIDTH)])
+    let [diff, _sidebar] =
+        Layout::horizontal([Constraint::Fill(1), Constraint::Length(SIDEBAR_WIDTH)])
             .areas(main_area);
 
     Rect {
@@ -172,21 +192,22 @@ mod tests {
     fn file_list_area_standard_frame() {
         let frame = Rect::new(0, 0, 80, 24);
         let area = file_list_area(frame);
-        assert_eq!(area.width, FILE_LIST_WIDTH);
+        assert_eq!(area.width, SIDEBAR_WIDTH);
     }
 
     #[test]
     fn file_list_area_x_is_frame_width_minus_sidebar() {
         let frame = Rect::new(0, 0, 80, 24);
         let area = file_list_area(frame);
-        assert_eq!(area.x, 80 - FILE_LIST_WIDTH);
+        assert_eq!(area.x, 80 - SIDEBAR_WIDTH);
     }
 
     #[test]
-    fn file_list_area_height_is_frame_height_minus_3() {
+    fn file_list_area_height_is_frame_minus_status_minus_commits() {
         let frame = Rect::new(0, 0, 80, 24);
         let area = file_list_area(frame);
-        assert_eq!(area.height, 24 - 3);
+        // 24 - 3 (status bar) - COMMIT_LIST_HEIGHT
+        assert_eq!(area.height, 24 - 3 - COMMIT_LIST_HEIGHT);
     }
 
     // ── diff_area tests ──────────────────────────────────────────────
@@ -203,7 +224,7 @@ mod tests {
     fn diff_area_width_is_frame_minus_sidebar_minus_borders() {
         let frame = Rect::new(0, 0, 80, 24);
         let area = diff_area(frame);
-        assert_eq!(area.width, 80 - FILE_LIST_WIDTH - 2);
+        assert_eq!(area.width, 80 - SIDEBAR_WIDTH - 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Commits pane below file list in the sidebar showing commits between main..HEAD
- Click commits to toggle include/exclude — file list and diffs update accordingly
- All commits selected by default (full diff against main)
- Deselecting commits narrows the diff to only selected commit range
- Sidebar widened to 28 chars, file list scrolls via ratatui ListState
- New git2 functions: `list_commits`, `diff_commit_range`, `diff_commit_range_file`

## Test plan
- [x] 132 tests passing (4 new git tests for commit listing and range diffing)
- [x] Existing render/event tests updated for new layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)