### PR TITLE
feat: draggable sidebar width (#16)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -41,6 +41,8 @@ pub struct App {
     /// The OID of the main branch commit (base for diffs).
     pub main_oid: Option<Oid>,
     pub file_scroll: usize,
+    pub sidebar_width: u16,
+    pub dragging_sidebar: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -79,6 +81,8 @@ impl App {
             commit_list_state: ListState::default(),
             main_oid: None,
             file_scroll: 0,
+            sidebar_width: crate::ui::DEFAULT_SIDEBAR_WIDTH,
+            dragging_sidebar: false,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,6 +200,14 @@ fn handle_mouse(
         MouseEventKind::Down(MouseButton::Left) => {
             handle_mouse_click(app, mouse.column, mouse.row, frame_size);
         }
+        MouseEventKind::Drag(MouseButton::Left) if app.dragging_sidebar => {
+            // Dragging: sidebar width = frame_width - mouse column
+            let new_width = frame_size.width.saturating_sub(mouse.column);
+            app.sidebar_width = ui::clamp_sidebar_width(new_width, frame_size.width);
+        }
+        MouseEventKind::Up(MouseButton::Left) => {
+            app.dragging_sidebar = false;
+        }
         MouseEventKind::ScrollUp => {
             app.diff_scroll = app.diff_scroll.saturating_sub(3);
         }
@@ -217,8 +225,17 @@ fn handle_mouse(
 }
 
 fn handle_mouse_click(app: &mut App, col: u16, row: u16, frame_size: ratatui::layout::Rect) {
+    let sw = app.sidebar_width;
+
+    // Check if click is on the sidebar border (start drag)
+    let border_col = ui::sidebar_border_col(frame_size, sw);
+    if col == border_col || col == border_col.saturating_sub(1) {
+        app.dragging_sidebar = true;
+        return;
+    }
+
     // Check if click is in file list
-    let file_area = ui::file_list_area(frame_size);
+    let file_area = ui::file_list_area(frame_size, sw);
     if col >= file_area.x
         && col < file_area.x + file_area.width
         && row > file_area.y
@@ -236,7 +253,7 @@ fn handle_mouse_click(app: &mut App, col: u16, row: u16, frame_size: ratatui::la
     }
 
     // Check if click is in commit list
-    let commit_area = ui::commit_list_area(frame_size);
+    let commit_area = ui::commit_list_area(frame_size, sw);
     if col >= commit_area.x
         && col < commit_area.x + commit_area.width
         && row > commit_area.y
@@ -252,7 +269,7 @@ fn handle_mouse_click(app: &mut App, col: u16, row: u16, frame_size: ratatui::la
     }
 
     // Check if click is in diff area
-    let diff_inner = ui::diff_area(frame_size);
+    let diff_inner = ui::diff_area(frame_size, sw);
     if col >= diff_inner.x
         && col < diff_inner.x + diff_inner.width
         && row >= diff_inner.y
@@ -668,7 +685,7 @@ mod tests {
     #[test]
     fn mouse_click_file_list_selects_file() {
         let mut app = make_test_app();
-        let file_area = ui::file_list_area(frame_size());
+        let file_area = ui::file_list_area(frame_size(), ui::DEFAULT_SIDEBAR_WIDTH);
         // Click on the second file (row = file_area.y + 1 for border + 1 for second item)
         let click_col = file_area.x + 1;
         let click_row = file_area.y + 2; // border row + first item row -> second item
@@ -681,7 +698,7 @@ mod tests {
     #[test]
     fn mouse_click_diff_area_starts_commenting() {
         let mut app = make_test_app();
-        let diff_inner = ui::diff_area(frame_size());
+        let diff_inner = ui::diff_area(frame_size(), ui::DEFAULT_SIDEBAR_WIDTH);
         // Click on the first visible row of the diff
         let click_col = diff_inner.x + 1;
         let click_row = diff_inner.y;
@@ -699,7 +716,7 @@ mod tests {
         let mut app = make_test_app();
         app.mode = Mode::Commenting;
         app.commenting_line = Some(0);
-        let diff_inner = ui::diff_area(frame_size());
+        let diff_inner = ui::diff_area(frame_size(), ui::DEFAULT_SIDEBAR_WIDTH);
         let click_col = diff_inner.x + 1;
         let click_row = diff_inner.y;
         handle_event(&mut app, mouse_click(click_col, click_row), frame_size());

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -12,8 +12,12 @@ use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::Frame;
 use status_bar::StatusBarWidget;
 
-/// Width of the sidebar (file list + commit list)
-const SIDEBAR_WIDTH: u16 = 28;
+/// Default width of the sidebar (file list + commit list)
+pub const DEFAULT_SIDEBAR_WIDTH: u16 = 28;
+/// Minimum sidebar width
+const MIN_SIDEBAR_WIDTH: u16 = 16;
+/// Minimum diff pane width
+const MIN_DIFF_WIDTH: u16 = 20;
 /// Height of the commit list pane
 const COMMIT_LIST_HEIGHT: u16 = 10;
 
@@ -21,9 +25,9 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     let [main_area, status_area] =
         Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).areas(frame.area());
 
+    let sidebar_w = app.sidebar_width;
     let [diff_area, sidebar_area] =
-        Layout::horizontal([Constraint::Fill(1), Constraint::Length(SIDEBAR_WIDTH)])
-            .areas(main_area);
+        Layout::horizontal([Constraint::Fill(1), Constraint::Length(sidebar_w)]).areas(main_area);
 
     let [files_area, commits_area] =
         Layout::vertical([Constraint::Fill(1), Constraint::Length(COMMIT_LIST_HEIGHT)])
@@ -55,11 +59,11 @@ pub(crate) fn short_path(path: &str) -> &str {
 }
 
 /// Compute sidebar layout areas.
-fn sidebar_areas(frame_area: Rect) -> (Rect, Rect) {
+fn sidebar_areas(frame_area: Rect, sidebar_width: u16) -> (Rect, Rect) {
     let [main_area, _status] =
         Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).areas(frame_area);
     let [_diff, sidebar] =
-        Layout::horizontal([Constraint::Fill(1), Constraint::Length(SIDEBAR_WIDTH)])
+        Layout::horizontal([Constraint::Fill(1), Constraint::Length(sidebar_width)])
             .areas(main_area);
     let [files, commits] =
         Layout::vertical([Constraint::Fill(1), Constraint::Length(COMMIT_LIST_HEIGHT)])
@@ -68,22 +72,22 @@ fn sidebar_areas(frame_area: Rect) -> (Rect, Rect) {
 }
 
 /// Returns the area occupied by the file list panel.
-pub fn file_list_area(frame_area: Rect) -> Rect {
-    sidebar_areas(frame_area).0
+pub fn file_list_area(frame_area: Rect, sidebar_width: u16) -> Rect {
+    sidebar_areas(frame_area, sidebar_width).0
 }
 
 /// Returns the area occupied by the commit list panel.
-pub fn commit_list_area(frame_area: Rect) -> Rect {
-    sidebar_areas(frame_area).1
+pub fn commit_list_area(frame_area: Rect, sidebar_width: u16) -> Rect {
+    sidebar_areas(frame_area, sidebar_width).1
 }
 
 /// Returns the inner area of the diff panel (inside borders).
-pub fn diff_area(frame_area: Rect) -> Rect {
+pub fn diff_area(frame_area: Rect, sidebar_width: u16) -> Rect {
     let [main_area, _status] =
         Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).areas(frame_area);
 
     let [diff, _sidebar] =
-        Layout::horizontal([Constraint::Fill(1), Constraint::Length(SIDEBAR_WIDTH)])
+        Layout::horizontal([Constraint::Fill(1), Constraint::Length(sidebar_width)])
             .areas(main_area);
 
     Rect {
@@ -92,6 +96,22 @@ pub fn diff_area(frame_area: Rect) -> Rect {
         width: diff.width.saturating_sub(2),
         height: diff.height.saturating_sub(2),
     }
+}
+
+/// Returns the column of the sidebar border (for drag detection).
+pub fn sidebar_border_col(frame_area: Rect, sidebar_width: u16) -> u16 {
+    let [main_area, _status] =
+        Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).areas(frame_area);
+    let [diff, _sidebar] =
+        Layout::horizontal([Constraint::Fill(1), Constraint::Length(sidebar_width)])
+            .areas(main_area);
+    diff.x + diff.width
+}
+
+/// Clamp sidebar width to valid range for a given frame width.
+pub fn clamp_sidebar_width(width: u16, frame_width: u16) -> u16 {
+    let max_width = frame_width.saturating_sub(MIN_DIFF_WIDTH);
+    width.clamp(MIN_SIDEBAR_WIDTH, max_width)
 }
 
 #[cfg(test)]
@@ -191,21 +211,21 @@ mod tests {
     #[test]
     fn file_list_area_standard_frame() {
         let frame = Rect::new(0, 0, 80, 24);
-        let area = file_list_area(frame);
-        assert_eq!(area.width, SIDEBAR_WIDTH);
+        let area = file_list_area(frame, DEFAULT_SIDEBAR_WIDTH);
+        assert_eq!(area.width, DEFAULT_SIDEBAR_WIDTH);
     }
 
     #[test]
     fn file_list_area_x_is_frame_width_minus_sidebar() {
         let frame = Rect::new(0, 0, 80, 24);
-        let area = file_list_area(frame);
-        assert_eq!(area.x, 80 - SIDEBAR_WIDTH);
+        let area = file_list_area(frame, DEFAULT_SIDEBAR_WIDTH);
+        assert_eq!(area.x, 80 - DEFAULT_SIDEBAR_WIDTH);
     }
 
     #[test]
     fn file_list_area_height_is_frame_minus_status_minus_commits() {
         let frame = Rect::new(0, 0, 80, 24);
-        let area = file_list_area(frame);
+        let area = file_list_area(frame, DEFAULT_SIDEBAR_WIDTH);
         // 24 - 3 (status bar) - COMMIT_LIST_HEIGHT
         assert_eq!(area.height, 24 - 3 - COMMIT_LIST_HEIGHT);
     }
@@ -215,7 +235,7 @@ mod tests {
     #[test]
     fn diff_area_standard_frame() {
         let frame = Rect::new(0, 0, 80, 24);
-        let area = diff_area(frame);
+        let area = diff_area(frame, DEFAULT_SIDEBAR_WIDTH);
         assert!(area.width > 0);
         assert!(area.height > 0);
     }
@@ -223,21 +243,21 @@ mod tests {
     #[test]
     fn diff_area_width_is_frame_minus_sidebar_minus_borders() {
         let frame = Rect::new(0, 0, 80, 24);
-        let area = diff_area(frame);
-        assert_eq!(area.width, 80 - SIDEBAR_WIDTH - 2);
+        let area = diff_area(frame, DEFAULT_SIDEBAR_WIDTH);
+        assert_eq!(area.width, 80 - DEFAULT_SIDEBAR_WIDTH - 2);
     }
 
     #[test]
     fn diff_area_height_is_frame_minus_status_minus_borders() {
         let frame = Rect::new(0, 0, 80, 24);
-        let area = diff_area(frame);
+        let area = diff_area(frame, DEFAULT_SIDEBAR_WIDTH);
         assert_eq!(area.height, 24 - 3 - 2);
     }
 
     #[test]
     fn diff_area_position() {
         let frame = Rect::new(0, 0, 80, 24);
-        let area = diff_area(frame);
+        let area = diff_area(frame, DEFAULT_SIDEBAR_WIDTH);
         assert_eq!(area.x, 1);
         assert_eq!(area.y, 1);
     }


### PR DESCRIPTION
## Summary
- Click and drag the border between diff pane and sidebar to resize
- Sidebar width clamped between 16 and frame_width - 20
- Width stored in `App.sidebar_width`, initialized to 28 (default)
- Drag starts on mouse down at border column, ends on mouse up
- All layout helpers now take `sidebar_width` parameter

## Test plan
- [x] 132 tests passing
- [x] Clippy clean
- [x] Existing layout/area tests updated for parameterized width

🤖 Generated with [Claude Code](https://claude.com/claude-code)